### PR TITLE
Feature/chef 12 dep update

### DIFF
--- a/daptiv-chef-ci.gemspec
+++ b/daptiv-chef-ci.gemspec
@@ -46,7 +46,7 @@ Gem::Specification.new do |gem|
   gem.version       = '0.1.0'
 
   gem.add_runtime_dependency 'log4r', '~> 1.1.10'
-  gem.add_runtime_dependency 'mixlib-shellout', '~> 1.2'
+  gem.add_runtime_dependency 'mixlib-shellout', '~> 2.0'
   gem.add_runtime_dependency 'versionomy', '~> 0.4.4'
 
   gem.add_development_dependency 'rake'

--- a/daptiv-chef-ci.gemspec
+++ b/daptiv-chef-ci.gemspec
@@ -43,7 +43,7 @@ Gem::Specification.new do |gem|
   gem.test_files    = gem.files.grep(%r{^(test|spec|features)/})
   gem.name          = 'daptiv-chef-ci'
   gem.require_paths = ['lib']
-  gem.version       = '0.1.0'
+  gem.version       = '0.1.1'
 
   gem.add_runtime_dependency 'log4r', '~> 1.1.10'
   gem.add_runtime_dependency 'mixlib-shellout', '~> 2.0'


### PR DESCRIPTION
- [x] @sweitzel74 

need to update mixlib-shellout version so there's no conflict with Chef 12.

Excerpt:
```
Bundler could not find compatible versions for gem "mixlib-shellout":
  In Gemfile:
    mixlib-shellout (< 3.0, >= 2.0.0.rc.0) ruby

    chef (~> 12.0.0) ruby depends on
      ohai (~> 8.0) ruby depends on
        mixlib-shellout (~> 2.0) ruby

    daptiv-chef-ci (~> 0.0.14) ruby depends on
      mixlib-shellout (~> 1.2.0) ruby
```